### PR TITLE
Add GHA for `staticcheck` and address issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,20 @@ jobs:
       - name: Build
         run: go build ./...
 
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: WillAbides/setup-go-faster@v1.14.0
+        with:
+          go-version-file: 'go.mod'
+
+      - uses: dominikh/staticcheck-action@v1.3.1
+        with:
+          version: latest
+          install-go: false
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Tested changes with `OnRamp` using the `replace` directive in the `amf` and `smf` go modules (Docker images)
The changes in this PR address the issues shown by `staticcheck`
```
$ staticcheck ./...
proto/client/gClient.go:38:2: field sst is unused (U1000)
proto/client/gClient.go:39:2: field sd is unused (U1000)
proto/client/gClient.go:143:35: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x.  (SA1019)
proto/client/gClient.go:144:14: grpc.Dial is deprecated: use NewClient instead.  Will be supported throughout 1.x.  (SA1019)
proto/client/gClient.go:219:6: func readConfigInLoop is unused (U1000)
proto/client/gClient.go:222:2: should use for range instead of for { select {} } (S1000)
```