### PR TITLE
fix: adding max retry count while trying to subscribe to a nms pod

### DIFF
--- a/proto/client/gClient.go
+++ b/proto/client/gClient.go
@@ -188,10 +188,6 @@ func (confClient *ConfigClient) subscribeToConfigPod(commChan chan *protos.Netwo
 			}
 		}
 
-		if stream == nil {
-			break
-		}
-
 		rsp, err := stream.Recv()
 		if err != nil {
 			logger.GrpcLog.Errorf("Failed to receive message: %v", err)


### PR DESCRIPTION

If the Webconsole is restarted, other modules loses the GRPC connection to Webconsole 
They tries to connect again for hours with no success. 
```
2024-09-26T11:32:10.014Z [smf] 2024-09-26T11:32:10Z [ERRO][Config5g][GRPC] Connectivity status idle, trying to connect again.
```

We add a max retry count which breaks the loop if max retry count is exceeded.